### PR TITLE
使用更全的ssfn数据库替代ssfnbox.com

### DIFF
--- a/SteamSSFN/Form1.cs
+++ b/SteamSSFN/Form1.cs
@@ -53,7 +53,8 @@ namespace SteamSSFN
         {
             if (File.Exists("temp")) File.Delete("temp");
             //获取ssfn下载地址
-            HttpDownloadFile("https://ssfnbox.com/download/" + textBox1.Text, "temp");
+            HttpDownloadFile("http://124.222.242.85/home/ssfn/" + textBox1.Text, "temp");//抓包找到的大D的数据库
+            //HttpDownloadFile("https://ssfnbox.com/download/" + textBox1.Text, "temp");
             string ssfnURL = GetBetweenStr(File.ReadAllLines("temp")[12], "window.location.assign(\"", "\"");
             if (string.IsNullOrEmpty(ssfnURL))
             {


### PR DESCRIPTION
http://124.222.242.85/www/wwwroot/ssfn/
如上
是用学校电脑抓包抓到的某卡网的ssfn数据库，在学校没有使用vs的条件，建议可以加个Checkbox切换数据库